### PR TITLE
Added tab character conversion to single space

### DIFF
--- a/src/DocxExtractor.php
+++ b/src/DocxExtractor.php
@@ -48,6 +48,7 @@ class DocxExtractor
 			'</w:r></w:p></w:tc><w:tc>' => " ",
 			'</w:r></w:p>' => "\r\n",
 			'</w:p>' => "\r\n",
+			'<w:tab/>' => " ",
 		]);
 
 		return strip_tags($text);


### PR DESCRIPTION
I've found in my use that I'd rather the Tab characters are converted into a single space.

Only a small change, but you might find it useful.
